### PR TITLE
For resource_usecost=false: make increments work properly

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1731,6 +1731,8 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 				 	* Setup the resource portal increments, ready to be added.
 					*/
 					incData.pid = MyProc->pid;
+					// Setup with INVALID_PORTALID as in this case we have one increment per session, not per portal
+					incData.portalId = INVALID_PORTALID;
 					incData.increments[RES_COUNT_LIMIT] = 1;
 
 					if (gp_resqueue_memory_policy != RESQUEUE_MEMORY_POLICY_NONE)
@@ -1759,6 +1761,8 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 				case T_CopyStmt:
 				{
 					incData.pid = MyProc->pid;
+					// Setup with INVALID_PORTALID as in this case we have one increment per session, not per portal
+					incData.portalId = INVALID_PORTALID;
 					incData.increments[RES_COUNT_LIMIT] = 1;
 					incData.increments[RES_MEMORY_LIMIT] = (Cost) 0.0;
 

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -1136,7 +1136,7 @@ queueid, portal->portalId);
 			pgstat_report_waiting(PGBE_WAITING_NONE);
 
 			/* If we had acquired the resource queue lock, release it and clean up */
-			ResLockRelease(&tag, -1);
+			ResLockRelease(&tag, INVALID_PORTALID);
 
 			PG_RE_THROW();
 		}
@@ -1171,6 +1171,6 @@ ResLockPreUnlock()
 			queueid);
 	#endif
 
-		ResLockRelease(&tag, -1);
+		ResLockRelease(&tag, INVALID_PORTALID);
 	}
 }


### PR DESCRIPTION
Make increments work with the new RQ design (early lock). In this case we don't have a portal, so make the increment key as <pid>,INVALID_PORTALID.
