### PR TITLE
Don't call ResLockUtilityPortal() if early RQ locking

### DIFF
--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -1064,6 +1064,7 @@ ResHandleUtilityStmt(Portal portal, Node *stmt)
 	if (Gp_role == GP_ROLE_DISPATCH
 		&& ResourceScheduler
 		&& (!ResourceSelectOnly)
+		&& ResourceQueueUseCost
 		&& !superuser())
 	{
 		Assert(!LWLockHeldExclusiveByMe(ResQueueLock));


### PR DESCRIPTION
There was one missed place where ResLockAcquire() is called through ProtalRunMulti()->PortalRunUtility()->ResHandleUtilityStmt()->ResLockUtilityPortal()->ResLockAcquire(), which was not checked for ResourceQueueUseCost. In the case of COPY, this caused a second call to ResLockAcquire():

lpetrov=> copy test from stdin;
WARNING:  duplicate portal id 0 for proc 4087
ERROR:  out of shared memory adding portal increments
HINT:  You may need to increase max_resource_portals_per_transaction.

Basically we check ResourceQueueUseCost for ResLockPortal() (in PortalStart(), ProcessQuery(), _SPI_pquery()), but we don't check for the similar ResLockUtilityPortal() in ResHandleUtilityStmt(). This seems the only place left, no others - and ResLockAcquire() is called only from ResLockPortal() and ResLockUtilityPortal() (aside from ResLockPrelock()).

I added the check and now everything works well.
