### PR TITLE
A couple of minor fixes

### DIFF
--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1174,7 +1174,6 @@ ResProcLockRemoveSelfAndWakeup(LOCK *lock)
 	PGPROC		*proc;
 	uint32		hashcode;
 	LWLockId	partitionLock;
-	ResPortalIncrement	incData;
 
 	int			status;
 

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -551,8 +551,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	ResPortalIncrement	*incrementSet;
 	ResPortalTag		portalTag;
 
-	ResPortalIncrement	single_activeData;
-
 	/* Check the lock method bits. */
 	Assert(locktag->locktag_lockmethodid == RESOURCE_LOCKMETHOD);
 
@@ -645,9 +643,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	incrementSet = ResIncrementFind(&portalTag);
 	if (!incrementSet)
 	{
-
-		ResLockUpdateLimit(lock, proclock, &single_activeData, false);
-
 		elog(DEBUG1, "Resource queue %d: increment not found on unlock", locktag->locktag_field1);
 		if (proclock->nLocks == 0)
 		{


### PR DESCRIPTION
1) Unused variable (generates compiler warning)
2) A noop in ResLockRelease() - ResLockUpdateLimit() with uninitialized increments.
