### PR TITLE
A couple of new fixes

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -1706,6 +1706,7 @@ exec_simple_query(const char *query_string, const char *seqServerHost, int seqSe
 		/* Check if resource scheduling is enabled and process accordingly */
 		if (Gp_role == GP_ROLE_DISPATCH && !superuser() && ResourceScheduler && !ResourceQueueUseCost)
 		{
+			memset(&incData, 0x00, sizeof(incData));
 			switch (nodeTag(parsetree))
 			{
 

--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -546,7 +546,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 	uint32			hashcode;
 	LWLockId		partitionLock;
 	ResourceOwner	owner;
-	uint64	ResQueueMemoryLimit;
 
 	ResPortalIncrement	*incrementSet;
 	ResPortalTag		portalTag;
@@ -586,8 +585,6 @@ ResLockRelease(LOCKTAG *locktag, uint32 resPortalId)
 
 		return false;
 	}
-
-	ResQueueMemoryLimit = ResourceQueueGetQueryMemoryLimit(NULL,GetResQueueId());
 
 	hashcode = locallock->hashcode;
 

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -559,6 +559,7 @@ ResLockPortal(Portal portal, QueryDesc *qDesc)
 	 */
 	if (queueid != InvalidOid)
 	{
+		memset(&incData, 0x00, sizeof(incData));
 
 		/*
 		 * Check the source tag to see if the original statement is suitable for
@@ -774,6 +775,7 @@ ResLockUtilityPortal(Portal portal, float4 ignoreCostLimit)
 		/*
 		 * Setup the resource portal increments, ready to be added.
 		 */
+		memset(&incData, 0x00, sizeof(incData));
 		incData.pid = MyProc->pid;
 		incData.portalId = portal->portalId;
 		incData.increments[RES_COUNT_LIMIT] = 1;


### PR DESCRIPTION
- initialize incData before use
- remove unnecessary call to ResourceQueueGetQueryMemoryLimit()
